### PR TITLE
Use sonar.token + set scanAll=false

### DIFF
--- a/sonarcloud/action.yml
+++ b/sonarcloud/action.yml
@@ -64,7 +64,7 @@ runs:
     - name: Build and analyze
       shell: bash
       run: |
-        ./sonar/scanner/dotnet-sonarscanner begin /k:"${{ inputs.sonarcloud-project-key }}" /o:"elvia" /d:sonar.login="${{ inputs.sonarcloud-token }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+        ./sonar/scanner/dotnet-sonarscanner begin /k:"${{ inputs.sonarcloud-project-key }}" /o:"elvia" /d:sonar.token="${{ inputs.sonarcloud-token }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.scanner.scanAll=false
 
         testprojects=`find . -iname "${{ inputs.test-projects }}"`
         for testproject in $testprojects;
@@ -72,7 +72,7 @@ runs:
           ./sonar/scanner/dotnet-coverage collect "dotnet test -l:trx $testproject" -f xml  -o 'coverage.xml'
         done
 
-        ./sonar/scanner/dotnet-sonarscanner end /d:sonar.login="${{ inputs.sonarcloud-token }}"
+        ./sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ inputs.sonarcloud-token }}"
       working-directory: ${{ inputs.working-directory }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }} # Needed to get PR information, if any


### PR DESCRIPTION
Sonar rapporterer om warnings:

```
The property 'sonar.login' is deprecated and will be removed in the future. 
Please use the 'sonar.token' property instead when passing a token.

Multi-Language analysis is enabled. If this was not intended and you have 
issues such as hitting your LOC limit or analyzing unwanted files, please set 
"/d:sonar.scanner.scanAll=false" in the begin step.
```
Prøver å fikse i denne PR'en