### PR TITLE
Update action.yml

### DIFF
--- a/vulnerabilities-slack-alert/action.yml
+++ b/vulnerabilities-slack-alert/action.yml
@@ -10,7 +10,7 @@ inputs:
       Slack API token. Within the Elvia organization, you can use GitHub organization secret `SLACK_API_TOKEN`.
     required: true
   github-token:
-    description: 'GitHub token is used to authenticate on behalf of the GitHub Actions workflow and for interacting with the GitHub API.
+    description: 'GitHub token is used to authenticate on behalf of the GitHub Actions workflow and for interacting with the GitHub API.'
     required: true
 
 runs:

--- a/vulnerabilities-slack-alert/action.yml
+++ b/vulnerabilities-slack-alert/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: |
       Slack API token. Within the Elvia organization, you can use GitHub organization secret `SLACK_API_TOKEN`.
     required: true
+  github-token:
+    description: 'GitHub token is used to authenticate on behalf of the GitHub Actions workflow and for interacting with the GitHub API.
+    required: true
 
 runs:
   using: 'composite'
@@ -17,7 +20,7 @@ runs:
       id: fetch-results
       shell: bash
       run: |
-        results=$(curl -v -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts")
+        results=$(curl -v -H "Authorization: token ${{ inputs.github-token }}" "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts")
 
         if [ $? -ne 0 ]; then
           echo "Failed to fetch code scanning results"


### PR DESCRIPTION
Fixed issue where workflow failed due to attempted access at secrets which is not a valid syntax for composite workflow. Replaced `secrets.*` with `inputs.*` to resolve this issue and now requires user to pass in GITHUB_TOKEN as a parameter.