### PR TITLE
Update vulnerability-slack-alert action.yml

### DIFF
--- a/vulnerabilities-slack-alert/action.yml
+++ b/vulnerabilities-slack-alert/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'Slack channel to send message to. The app "Github Workflow Notifications" must be added to the channel.'
     required: true
   environment:
-    description: 'Environment is used to find the correct Vault instance.'
+    description: 'Environment is used to find the correct Vault instance. Eg. `test`, `dev`, `prod` and other.'
     required: true
   namespace:
     description: 'Namespace is used to find the correct Vault role.'

--- a/vulnerabilities-slack-alert/action.yml
+++ b/vulnerabilities-slack-alert/action.yml
@@ -5,9 +5,11 @@ inputs:
   slack-channel:
     description: 'Slack channel to send message to. The app "Github Workflow Notifications" must be added to the channel.'
     required: true
-  slack-api-token:
-    description: |
-      Slack API token. Within the Elvia organization, you can use GitHub organization secret `SLACK_API_TOKEN`.
+  environment:
+    description: 'Environment is used to find the correct Vault instance.'
+    required: true
+  namespace:
+    description: 'Namespace is used to find the correct Vault role.'
     required: true
   github-token:
     description: |
@@ -88,6 +90,7 @@ runs:
     - name: Send Slack Message
       uses: 3lvia/core-github-actions-templates/slack-message@trunk
       with:
-        message: ${{ steps.construct-slack-message.outputs.message }}
-        slack-api-token: ${{ inputs.slack-api-token }}
         slack-channel: ${{ inputs.slack-channel }}
+        message: ${{ steps.construct-slack-message.outputs.message }}
+        environment: ${{ inputs.environment }}
+        namespace: ${{ inputs.namespace }}


### PR DESCRIPTION
Updated action to require user to input environment and namespace. 
slack-api-token input is no longer in use.