### PR TITLE
Fix sonar coverage

### DIFF
--- a/sonarcloud/action.yml
+++ b/sonarcloud/action.yml
@@ -69,7 +69,7 @@ runs:
         testprojects=`find . -iname "${{ inputs.test-projects }}"`
         for testproject in $testprojects;
         do
-          ./sonar/scanner/dotnet-coverage collect "dotnet test -l:trx $testproject" -f xml  -o '$(uuidgen)_coverage.xml'
+          ./sonar/scanner/dotnet-coverage collect "dotnet test -l:trx $testproject" -f xml  -o "$(uuidgen)_coverage.xml"
         done
 
         ./sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ inputs.sonarcloud-token }}"

--- a/sonarcloud/action.yml
+++ b/sonarcloud/action.yml
@@ -64,12 +64,12 @@ runs:
     - name: Build and analyze
       shell: bash
       run: |
-        ./sonar/scanner/dotnet-sonarscanner begin /k:"${{ inputs.sonarcloud-project-key }}" /o:"elvia" /d:sonar.token="${{ inputs.sonarcloud-token }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml /d:sonar.scanner.scanAll=false
+        ./sonar/scanner/dotnet-sonarscanner begin /k:"${{ inputs.sonarcloud-project-key }}" /o:"elvia" /d:sonar.token="${{ inputs.sonarcloud-token }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=*_coverage.xml /d:sonar.scanner.scanAll=false
 
         testprojects=`find . -iname "${{ inputs.test-projects }}"`
         for testproject in $testprojects;
         do
-          ./sonar/scanner/dotnet-coverage collect "dotnet test -l:trx $testproject" -f xml  -o 'coverage.xml'
+          ./sonar/scanner/dotnet-coverage collect "dotnet test -l:trx $testproject" -f xml  -o '$(uuidgen)_coverage.xml'
         done
 
         ./sonar/scanner/dotnet-sonarscanner end /d:sonar.token="${{ inputs.sonarcloud-token }}"


### PR DESCRIPTION
Alle testprosjektene ble kjørt med samme coverage-fil: `coverage.xml`

Dette gjorde at det bare var coverage for siste testprosjekt som ble lastet opp til SonarCloud.

Fikset her ved å generere filnavn med guid-prefix + laste opp alle filer som slutter på coverage.xml

Har testet at dette funker for meldingsportalen