### PR TITLE
Dry-run deploy everything except demo-api

### DIFF
--- a/.github/workflows/example-build-deploy-dockerfile-google.yml
+++ b/.github/workflows/example-build-deploy-dockerfile-google.yml
@@ -108,6 +108,7 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-test:
@@ -155,6 +156,7 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-prod:
@@ -202,4 +204,5 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE

--- a/.github/workflows/example-build-deploy-dockerfile.yml
+++ b/.github/workflows/example-build-deploy-dockerfile.yml
@@ -106,6 +106,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-test:
@@ -151,6 +152,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-prod:
@@ -196,4 +198,5 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE

--- a/.github/workflows/example-build-deploy-go-google.yml
+++ b/.github/workflows/example-build-deploy-go-google.yml
@@ -148,6 +148,7 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-test:
@@ -195,6 +196,7 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-prod:
@@ -242,4 +244,5 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE

--- a/.github/workflows/example-build-deploy-go.yml
+++ b/.github/workflows/example-build-deploy-go.yml
@@ -146,6 +146,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-test:
@@ -191,6 +192,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-prod:
@@ -236,4 +238,5 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE

--- a/.github/workflows/example-build-deploy-python-google.yml
+++ b/.github/workflows/example-build-deploy-python-google.yml
@@ -148,6 +148,7 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-test:
@@ -195,6 +196,7 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-prod:
@@ -242,4 +244,5 @@ jobs:
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE

--- a/.github/workflows/example-build-deploy-python.yml
+++ b/.github/workflows/example-build-deploy-python.yml
@@ -146,6 +146,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-test:
@@ -191,6 +192,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE
 
   deploy-prod:
@@ -236,4 +238,5 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
 # START REMOVE FROM EXAMPLE
           checkout: 'false'
+          dry-run: 'true'
 # END REMOVE FROM EXAMPLE

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -329,7 +329,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   deploy-argocd:
-    name: 'Deploy ${{ matrix.environment }} with Argo CD'
+    name: Deploy Argo CD
     needs: [prepare-jobs, build]
     strategy:
       fail-fast: false

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -64,7 +64,6 @@ jobs:
               "applications/demo-api-go/Dockerfile",
               "applications/demo-api-python/pyproject.toml"
             ],
-            "registry": ["","ghcr.io/3lvia"],
             "include": [
               {
                 "application-name": "${{ env.APPLICATION_BASE_NAME }}-go"
@@ -229,7 +228,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-jobs.outputs.matrix-build) }}
     concurrency:
       group: |
-        ${{ github.workflow_ref }}-${{ matrix.runner }}-${{ matrix.application-name }}-${{ matrix.project-file }}-${{ matrix.registry }}
+        ${{ github.workflow_ref }}-${{ matrix.runner }}-${{ matrix.application-name }}-${{ matrix.project-file }}
       cancel-in-progress: true
     runs-on: ${{ matrix.runner }}
     permissions:
@@ -240,7 +239,9 @@ jobs:
       pull-requests: write
       security-events: write
     outputs:
-      image: ${{ steps.build.outputs.image-name-with-digest }}
+      image-demo-api: ${{ steps.build-demo-api.outputs.image-name-with-digest }}
+      image-demo-api-go: ${{ steps.build-demo-api-go.outputs.image-name-with-digest }}
+      image-demo-api-python: ${{ steps.build-demo-api-python.outputs.image-name-with-digest }}
     environment: build
     steps:
       - name: Checkout this repository
@@ -263,14 +264,13 @@ jobs:
           path: 'core'
 
       - uses: ./build
-        id: build
+        id: 'build-${{ matrix.application-name }}'
         with:
           checkout: 'false'
           name: ${{ matrix.application-name }}
           namespace: ${{ env.SYSTEM_NAME }}
           project-file: 'core/${{ matrix.project-file }}'
           docker-additional-tags: 'v42,v1.2.3'
-          registry: ${{ matrix.registry }}
           trivy-upload-report: 'true'
           trivy-post-comment: 'true'
           AZURE_CLIENT_ID: ${{ vars.ACR_CLIENT_ID }}
@@ -370,7 +370,7 @@ jobs:
           name: ${{ matrix.application-name }}
           system: ${{ env.SYSTEM_NAME }}
           environment: ${{ matrix.environment }}
-          image: ${{ needs.build.outputs.image }}
+          image: ${{ matrix.application-name == 'demo-api-go' && needs.build.outputs.image-demo-api-go || needs.build.outputs.image-demo-api-python }}
           slack-channel: '#team-core-alerts-muted'
           ACR_USERNAME: ${{ vars.ACR_USERNAME }}
           ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -239,9 +239,9 @@ jobs:
       pull-requests: write
       security-events: write
     outputs:
-      image-demo-api: ${{ steps.build.outputs.image-name-with-digest-demo-api }}
-      image-demo-api-go: ${{ steps.build.outputs.image-name-with-digest-demo-api-go }}
-      image-demo-api-python: ${{ steps.build.outputs.image-name-with-digest-demo-api-python }}
+      image-demo-api: ${{ steps.build-output.outputs.image-name-with-digest-demo-api }}
+      image-demo-api-go: ${{ steps.build-output.outputs.image-name-with-digest-demo-api-go }}
+      image-demo-api-python: ${{ steps.build-output.outputs.image-name-with-digest-demo-api-python }}
     environment: build
     steps:
       - name: Checkout this repository
@@ -276,7 +276,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.ACR_CLIENT_ID }}
 
       - name: Set build output
-        id: build
+        id: build-output
         run: echo "image-name-with-digest-$APPLICATION_NAME=$IMAGE_NAME_WITH_DIGEST" >> "$GITHUB_OUTPUT"
         env:
           APPLICATION_NAME: ${{ matrix.application-name }}

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -239,9 +239,9 @@ jobs:
       pull-requests: write
       security-events: write
     outputs:
-      image-demo-api: ${{ steps.build-demo-api.outputs.image-name-with-digest }}
-      image-demo-api-go: ${{ steps.build-demo-api-go.outputs.image-name-with-digest }}
-      image-demo-api-python: ${{ steps.build-demo-api-python.outputs.image-name-with-digest }}
+      image-demo-api: ${{ steps.build.outputs.image-name-with-digest-demo-api }}
+      image-demo-api-go: ${{ steps.build.outputs.image-name-with-digest-demo-api-go }}
+      image-demo-api-python: ${{ steps.build.outputs.image-name-with-digest-demo-api-python }}
     environment: build
     steps:
       - name: Checkout this repository
@@ -264,7 +264,6 @@ jobs:
           path: 'core'
 
       - uses: ./build
-        id: 'build-${{ matrix.application-name }}'
         with:
           checkout: 'false'
           name: ${{ matrix.application-name }}
@@ -274,6 +273,13 @@ jobs:
           trivy-upload-report: 'true'
           trivy-post-comment: 'true'
           AZURE_CLIENT_ID: ${{ vars.ACR_CLIENT_ID }}
+
+      - name: Set build output
+        id: build
+        run: echo "image-name-with-digest-$APPLICATION_NAME=$IMAGE_NAME_WITH_DIGEST" >> "$GITHUB_OUTPUT"
+        env:
+          APPLICATION_NAME: ${{ matrix.application-name }}
+          IMAGE_NAME_WITH_DIGEST: ${{ steps.build.outputs.image-name-with-digest }}
 
   build-vulnerable-service:
     name: Build Vulnerable Service

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -121,6 +121,7 @@ jobs:
             "runner": ["$RUNNER"],
             "application-name": [
               "${{ env.APPLICATION_BASE_NAME }}-go",
+              "${{ env.APPLICATION_BASE_NAME }}-python"
             ],
             environment: ["sandbox", "dev"]
           }
@@ -414,6 +415,7 @@ jobs:
           helm-chart-repository-url: 'https://raw.githubusercontent.com/3lvia/kubernetes-charts/819af167eae45675474fc833019fd50517136799'
           slack-channel: '#team-core-alerts-muted'
           runtime-cloud-provider: ${{ matrix.runtime-cloud-provider }}
+          dry-run: ${{ matrix.application-name == 'demo-api' && 'false' || 'true' }} # dry-run everything except demo-api, since rest is deployed via Argo CD
           AZURE_CLIENT_ID: ${{ vars.AKS_CLIENT_ID }}
           GC_SERVICE_ACCOUNT: ${{ vars.GC_SERVICE_ACCOUNT }}
           GC_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GC_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -264,6 +264,7 @@ jobs:
           path: 'core'
 
       - uses: ./build
+        id: build
         with:
           checkout: 'false'
           name: ${{ matrix.application-name }}

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -239,6 +239,8 @@ jobs:
       packages: write # Required for publishing to GitHub Container Registry
       pull-requests: write
       security-events: write
+    outputs:
+      image: ${{ steps.build.outputs.image-name-with-digest }}
     environment: build
     steps:
       - name: Checkout this repository
@@ -261,6 +263,7 @@ jobs:
           path: 'core'
 
       - uses: ./build
+        id: build
         with:
           checkout: 'false'
           name: ${{ matrix.application-name }}
@@ -367,6 +370,7 @@ jobs:
           name: ${{ matrix.application-name }}
           system: ${{ env.SYSTEM_NAME }}
           environment: ${{ matrix.environment }}
+          image: ${{ needs.build.outputs.image }}
           slack-channel: '#team-core-alerts-muted'
           ACR_USERNAME: ${{ vars.ACR_USERNAME }}
           ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -131,7 +131,7 @@ runs:
           -H "X-GitHub-OIDC-Token: $GH_ID_TOKEN" \
           -H 'X-Timeout: 3m' \
           -H 'Content-Type: application/json' \
-          -d "{\"image\":\"$IMAGE\",\"system\":\"$SYSTEM\",\"cluster_type\":\"$CLUSTER_TYPE\",\"environment\":\"$ENVIRONMENT\",\"application_name\":\"$NAME\",\"check_all_clusters\":\"$CHECK_ALL_CLUSTERS\"}" \
+          -d "{\"image\":\"$IMAGE\",\"system\":\"$SYSTEM\",\"cluster_type\":\"$CLUSTER_TYPE\",\"environment\":\"$ENVIRONMENT\",\"application_name\":\"$NAME\",\"check_all_clusters\":$CHECK_ALL_CLUSTERS}" \
           --fail-with-body \
           "$DEPLOYVIA_URL"
       env:

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -11,6 +11,12 @@ inputs:
     description: 'Type of cluster to check deployment status for. Can be `aks`, `gke` or `iss`.'
     required: true
     default: 'aks'
+  check-all-clusters:
+    description: |
+      If `true`, the action will check all clusters for deployment status.
+      If `false`, the action will only check the cluster specified in `cluster-type`.
+    required: false
+    default: 'false'
   environment:
     description: 'Environment to deploy to.'
     required: true
@@ -25,7 +31,9 @@ inputs:
     description: 'Password for Azure Container Registry, if using it.'
     required: true
   checkout:
-    description: 'If `true`, the action will check out the repository. If `false`, the action will assume the repository has already been checked out.'
+    description: |
+      If `true`, the action will check out the repository.
+      If `false`, the action will assume the repository has already been checked out.
     required: false
     default: 'true'
   slack-channel:
@@ -99,47 +107,6 @@ runs:
           let idToken = await core_.getIDToken()
           core_.setOutput('token', idToken)
 
-    - name: Check if image digest has changed
-      shell: bash
-      id: check-image-digest
-      run: |
-        # Check if image digest has changed
-
-        # NOTE: for some reason, skopeo inspect does not work, complains about 403.
-        # As a a workaround, we just pull the images and check the digests with docker inspect.
-        # Another option would be docker manifest inspect which supports not pulling, but the command is experimental.
-
-        if ! docker pull "$OLD_IMAGE"; then
-          echo 'Failed to pull old image. This may be expected if the image does not exist yet.'
-          echo 'Proceeding with deployment.'
-          echo 'skip-deployment=false' >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        docker pull "$NEW_IMAGE"
-
-        old_image_digest=$(docker inspect -f '{{index .RepoDigests 0}}' "$OLD_IMAGE" | cut -d '@' -f2)
-        new_image_digest=$(docker inspect -f '{{index .RepoDigests 0}}' "$NEW_IMAGE" | cut -d '@' -f2)
-
-        if [[ "$old_image_digest" == "$new_image_digest" ]]; then
-          echo 'Image digest has not changed from currently deployed image.'
-          printf 'Skipping deployment.\n\n'
-          echo "Currently deployed image: $OLD_IMAGE"
-          echo "Currently deployed digest: $old_image_digest"
-          echo "skip-deployment=true" >> "$GITHUB_OUTPUT"
-        else
-          echo 'Image digest has changed from currently deployed image.'
-          printf 'Proceeding with deployment.\n\n'
-          echo "Currently deployed image: $OLD_IMAGE"
-          printf 'Currently deployed digest: %s\n\n' "$old_image_digest"
-          echo "New image: $NEW_IMAGE"
-          echo "New digest: $new_image_digest"
-          echo "skip-deployment=false" >> "$GITHUB_OUTPUT"
-        fi
-      env:
-        OLD_IMAGE: ${{ format('{0}/{1}/{2}:{3}', inputs.registry, inputs.system, inputs.name, inputs.environment) }}
-        NEW_IMAGE: ${{ format('{0}/{1}/{2}:{3}-{4}', inputs.registry, inputs.system, inputs.name, github.sha, github.run_number) }}
-
     - name: Copy image to new tag and push
       if: ${{ steps.check-image-digest.outputs.skip-deployment != 'true' }}
       shell: bash
@@ -156,8 +123,9 @@ runs:
         # Wait for Argo CD application to sync
         curl -v \
           -H "X-GitHub-OIDC-Token: $GH_ID_TOKEN" \
+          -H 'X-Timeout: 3m' \
           -H 'Content-Type: application/json' \
-          -d "{\"image\":\"$IMAGE\",\"system\":\"$SYSTEM\",\"cluster_type\":\"$CLUSTER_TYPE\",\"environment\":\"$ENVIRONMENT\",\"application_name\":\"$NAME\"}" \
+          -d "{\"image\":\"$IMAGE\",\"system\":\"$SYSTEM\",\"cluster_type\":\"$CLUSTER_TYPE\",\"environment\":\"$ENVIRONMENT\",\"application_name\":\"$NAME\",\"check_all_clusters\":\"$CHECK_ALL_CLUSTERS\"}" \
           --fail-with-body \
           "$DEPLOYVIA_URL"
       env:
@@ -165,6 +133,7 @@ runs:
         NAME: ${{ inputs.name }}
         SYSTEM: ${{ inputs.system }}
         CLUSTER_TYPE: ${{ inputs.cluster-type }}
+        CHECK_ALL_CLUSTERS: ${{ inputs.check-all-clusters }}
         ENVIRONMENT: ${{ inputs.environment }}
         IMAGE: ${{ format('{0}/{1}/{2}:{3}', inputs.registry, inputs.system, inputs.name, inputs.environment) }}
         DEPLOYVIA_URL: ${{ format('https://deployvia.{0}/deployment', (inputs.environment == 'sandbox' && 'dev-elvia.io' || 'elvia.io')) }}

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -110,10 +110,13 @@ runs:
           let idToken = await core_.getIDToken()
           core_.setOutput('token', idToken)
 
-    - name: Copy image to new tag and push
+    - name: Copy image to tag ${{ inputs.environment }}
       if: ${{ steps.check-image-digest.outputs.skip-deployment != 'true' }}
       shell: bash
-      run: skopeo copy "docker://$IMAGE" "docker://$IMAGE_NAME:$ENVIRONMENT"
+      run: |
+        # Copy image to new tag and push
+        image_without_tag_and_or_digest="$(echo $IMAGE | cut -d':' -f1 | cut -d'@' -f1)"
+        skopeo copy "docker://$IMAGE" "docker://$image_without_tag_and_or_digest:$ENVIRONMENT"
       env:
         ENVIRONMENT: ${{ inputs.environment }}
         IMAGE: ${{ inputs.image }}

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -7,6 +7,9 @@ inputs:
   system:
     description: 'System (namespace) of the application.'
     required: true
+  image:
+    description: 'Full name of the image to deploy (including digest), e.g. `containerregistryelvia.azurecr.io/core/demo-api-go:v3@sha256:123456789abdefgh`.'
+    required: true
   cluster-type:
     description: 'Type of cluster to check deployment status for. Can be `aks`, `gke` or `iss`.'
     required: true
@@ -110,10 +113,10 @@ runs:
     - name: Copy image to new tag and push
       if: ${{ steps.check-image-digest.outputs.skip-deployment != 'true' }}
       shell: bash
-      run: skopeo copy "docker://$IMAGE_NAME:$IMAGE_TAG" "docker://$IMAGE_NAME:$ENVIRONMENT"
+      run: skopeo copy "docker://$IMAGE" "docker://$IMAGE_NAME:$ENVIRONMENT"
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        IMAGE_NAME: ${{ format('{0}/{1}/{2}', inputs.registry, inputs.system, inputs.name) }}
+        IMAGE: ${{ inputs.image }}
         IMAGE_TAG: ${{ format('{0}-{1}', github.sha, github.run_number) }}
 
     - name: Wait for Argo CD application to sync
@@ -135,5 +138,5 @@ runs:
         CLUSTER_TYPE: ${{ inputs.cluster-type }}
         CHECK_ALL_CLUSTERS: ${{ inputs.check-all-clusters }}
         ENVIRONMENT: ${{ inputs.environment }}
-        IMAGE: ${{ format('{0}/{1}/{2}:{3}', inputs.registry, inputs.system, inputs.name, inputs.environment) }}
+        IMAGE: ${{ inputs.image }}
         DEPLOYVIA_URL: ${{ format('https://deployvia.{0}/deployment', (inputs.environment == 'sandbox' && 'dev-elvia.io' || 'elvia.io')) }}

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -26,6 +26,10 @@ inputs:
   helm-chart-repository-url:
     description: "Location of Elvia's Helm chart repository; should only be changed if testing a new version of the chart."
     required: false
+  dry-run:
+    description: 'Simulate the deployment without actually deploying.'
+    required: false
+    default: 'false'
   workload-type:
     description: 'The type of workload to deploy to Kubernetes. Must be `deployment` or `statefulset`.'
     required: false
@@ -169,6 +173,7 @@ runs:
         3LV_GKE_CLUSTER_NAME: ${{ inputs.GKE_CLUSTER_NAME }}
         3LV_GKE_CLUSTER_LOCATION: ${{ inputs.GKE_CLUSTER_LOCATION }}
         3LV_HELM_CHART_REPOSITORY_URL: ${{ inputs.helm-chart-repository-url }}
+        3LV_DRY_RUN: ${{ inputs.dry-run }}
 
     - name: Notify Slack on failure
       if: ${{ failure() && inputs.slack-channel != '' }}


### PR DESCRIPTION
Hvis vi prøver å deploye via Helm og Argo CD samtidig så blir det masse kluss. Jeg bytter til at bare demo-api deployes via Helm, mens demo-api-go og demo-api-python deployes via Argo CD.