### PR TITLE
Fix skopeo digest change for environment tag

### DIFF
--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -80,14 +80,6 @@ runs:
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
 
-    #   - name: Login to GitHub Container Registry
-    #     if: contains(inputs.registry, 'ghcr.io')
-    #     uses: docker/login-action@v3
-    #     with:
-    #       registry: 'ghcr.io'
-    #       username: ${{ github.actor }}
-    #       password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Login to Azure Container Registry
       if: contains(inputs.registry, 'azurecr.io')
       uses: docker/login-action@v3
@@ -117,11 +109,11 @@ runs:
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
 
-    - name: Get ACR image digest
+    - name: Get ACR image digest for environment tag
       id: get-acr-digest
       shell: bash
       run: |
-        registry_full=$(echo "$IMAGE" | cut -d'/' -f1)
+        registry_with_domain=$(echo "$IMAGE" | cut -d'/' -f1)
         registry=$(echo "$IMAGE" | cut -d'/' -f1 | cut -d'.' -f1)
         repository=$(echo "$IMAGE" | cut -d'/' -f2- | cut -d'@' -f1)
 
@@ -137,7 +129,7 @@ runs:
           exit 1
         fi
 
-        full_image="$registry_full/$repository@$digest"
+        full_image="$registry_with_domain/$repository@$digest"
         echo "image_with_digest=$full_image" >> "$GITHUB_OUTPUT"
       env:
         IMAGE: ${{ inputs.image }}
@@ -172,7 +164,6 @@ runs:
         CLUSTER_TYPE: ${{ inputs.cluster-type }}
         CHECK_ALL_CLUSTERS: ${{ inputs.check-all-clusters }}
         ENVIRONMENT: ${{ inputs.environment }}
-        # IMAGE: ${{ inputs.image }}
         IMAGE:  ${{ steps.get-acr-digest.outputs.image_with_digest }}
         DEPLOYVIA_URL: ${{ format('https://deployvia.{0}/deployment', (inputs.environment == 'sandbox' && 'dev-elvia.io' || 'elvia.io')) }}
 

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -1,50 +1,50 @@
-name: "Deploy Argo CD"
-description: "Deploys an application to Kubernetes using Argo CD."
+name: 'Deploy Argo CD'
+description: 'Deploys an application to Kubernetes using Argo CD.'
 inputs:
   name:
-    description: "Name of application. Do not include namespace."
+    description: 'Name of application. Do not include namespace.'
     required: true
   system:
-    description: "System (namespace) of the application."
+    description: 'System (namespace) of the application.'
     required: true
   image:
-    description: "Name of image to deploy with digest (but without tag!), e.g. `containerregistryelvia.azurecr.io/core/demo-api-go@sha256:123456789abdefgh`."
+    description: 'Name of image to deploy with digest (but without tag!), e.g. `containerregistryelvia.azurecr.io/core/demo-api-go@sha256:123456789abdefgh`.'
     required: true
   cluster-type:
-    description: "Type of cluster to check deployment status for. Can be `aks`, `gke` or `iss`."
+    description: 'Type of cluster to check deployment status for. Can be `aks`, `gke` or `iss`.'
     required: true
-    default: "aks"
+    default: 'aks'
   check-all-clusters:
     description: |
       If `true`, the action will check all clusters for deployment status.
       If `false`, the action will only check the cluster specified in `cluster-type`.
     required: false
-    default: "false"
+    default: 'false'
   environment:
-    description: "Environment to deploy to."
+    description: 'Environment to deploy to.'
     required: true
   registry:
-    description: "Docker registry to use."
+    description: 'Docker registry to use.'
     required: false
-    default: "containerregistryelvia.azurecr.io"
+    default: 'containerregistryelvia.azurecr.io'
   ACR_USERNAME:
-    description: "Username for Azure Container Registry, if using it."
+    description: 'Username for Azure Container Registry, if using it.'
     required: true
   ACR_PASSWORD:
-    description: "Password for Azure Container Registry, if using it."
+    description: 'Password for Azure Container Registry, if using it.'
     required: true
   checkout:
     description: |
       If `true`, the action will check out the repository. If `false`, the action will assume the repository has already been checked out.
     required: false
-    default: "true"
+    default: 'true'
   slack-channel:
-    description: "Slack channel to notify on failure. Leave empty to disable notifications."
+    description: 'Slack channel to notify on failure. Leave empty to disable notifications.'
     required: false
-    default: ""
+    default: ''
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Validate required inputs
       shell: bash

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -79,15 +79,7 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
-
-    #   - name: Login to GitHub Container Registry
-    #     if: contains(inputs.registry, 'ghcr.io')
-    #     uses: docker/login-action@v3
-    #     with:
-    #       registry: 'ghcr.io'
-    #       username: ${{ github.actor }}
-    #       password: ${{ secrets.GITHUB_TOKEN }}
-
+        
     - name: Login to Azure Container Registry
       if: contains(inputs.registry, 'azurecr.io')
       uses: docker/login-action@v3
@@ -117,11 +109,11 @@ runs:
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
 
-    - name: Get ACR image digest
+    - name: Get ACR image digest for environment tag
       id: get-acr-digest
       shell: bash
       run: |
-        registry_full=$(echo "$IMAGE" | cut -d'/' -f1)
+        registry_with_domain=$(echo "$IMAGE" | cut -d'/' -f1)
         registry=$(echo "$IMAGE" | cut -d'/' -f1 | cut -d'.' -f1)
         repository=$(echo "$IMAGE" | cut -d'/' -f2- | cut -d'@' -f1)
 
@@ -137,7 +129,7 @@ runs:
           exit 1
         fi
 
-        full_image="$registry_full/$repository@$digest"
+        full_image="$registry_with_domain/$repository@$digest"
         echo "image_with_digest=$full_image" >> "$GITHUB_OUTPUT"
       env:
         IMAGE: ${{ inputs.image }}

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -1,50 +1,50 @@
-name: 'Deploy Argo CD'
-description: 'Deploys an application to Kubernetes using Argo CD.'
+name: "Deploy Argo CD"
+description: "Deploys an application to Kubernetes using Argo CD."
 inputs:
   name:
-    description: 'Name of application. Do not include namespace.'
+    description: "Name of application. Do not include namespace."
     required: true
   system:
-    description: 'System (namespace) of the application.'
+    description: "System (namespace) of the application."
     required: true
   image:
-    description: 'Name of image to deploy with digest (but without tag!), e.g. `containerregistryelvia.azurecr.io/core/demo-api-go@sha256:123456789abdefgh`.'
+    description: "Name of image to deploy with digest (but without tag!), e.g. `containerregistryelvia.azurecr.io/core/demo-api-go@sha256:123456789abdefgh`."
     required: true
   cluster-type:
-    description: 'Type of cluster to check deployment status for. Can be `aks`, `gke` or `iss`.'
+    description: "Type of cluster to check deployment status for. Can be `aks`, `gke` or `iss`."
     required: true
-    default: 'aks'
+    default: "aks"
   check-all-clusters:
     description: |
       If `true`, the action will check all clusters for deployment status.
       If `false`, the action will only check the cluster specified in `cluster-type`.
     required: false
-    default: 'false'
+    default: "false"
   environment:
-    description: 'Environment to deploy to.'
+    description: "Environment to deploy to."
     required: true
   registry:
-    description: 'Docker registry to use.'
+    description: "Docker registry to use."
     required: false
-    default: 'containerregistryelvia.azurecr.io'
+    default: "containerregistryelvia.azurecr.io"
   ACR_USERNAME:
-    description: 'Username for Azure Container Registry, if using it.'
+    description: "Username for Azure Container Registry, if using it."
     required: true
   ACR_PASSWORD:
-    description: 'Password for Azure Container Registry, if using it.'
+    description: "Password for Azure Container Registry, if using it."
     required: true
   checkout:
     description: |
       If `true`, the action will check out the repository. If `false`, the action will assume the repository has already been checked out.
     required: false
-    default: 'true'
+    default: "true"
   slack-channel:
-    description: 'Slack channel to notify on failure. Leave empty to disable notifications.'
+    description: "Slack channel to notify on failure. Leave empty to disable notifications."
     required: false
-    default: ''
+    default: ""
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Validate required inputs
       shell: bash
@@ -79,7 +79,7 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
-        
+
     - name: Login to Azure Container Registry
       if: contains(inputs.registry, 'azurecr.io')
       uses: docker/login-action@v3
@@ -164,7 +164,7 @@ runs:
         CLUSTER_TYPE: ${{ inputs.cluster-type }}
         CHECK_ALL_CLUSTERS: ${{ inputs.check-all-clusters }}
         ENVIRONMENT: ${{ inputs.environment }}
-        IMAGE:  ${{ steps.get-acr-digest.outputs.image_with_digest }}
+        IMAGE: ${{ steps.get-acr-digest.outputs.image_with_digest }}
         DEPLOYVIA_URL: ${{ format('https://deployvia.{0}/deployment', (inputs.environment == 'sandbox' && 'dev-elvia.io' || 'elvia.io')) }}
 
     - name: Notify Slack on failure

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -121,6 +121,7 @@ runs:
       id: get-acr-digest
       shell: bash
       run: |
+        registry_full=$(echo "$IMAGE" | cut -d'/' -f1)
         registry=$(echo "$IMAGE" | cut -d'/' -f1 | cut -d'.' -f1)
         repository=$(echo "$IMAGE" | cut -d'/' -f2- | cut -d'@' -f1)
 
@@ -136,7 +137,7 @@ runs:
           exit 1
         fi
 
-        full_image="$registry/$repository@$digest"
+        full_image="$registry_full/$repository@$digest"
         echo "image_with_digest=$full_image" >> "$GITHUB_OUTPUT"
       env:
         IMAGE: ${{ inputs.image }}

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -121,13 +121,12 @@ runs:
       id: get-acr-digest
       shell: bash
       run: |
-        registry=$(echo "$IMAGE" | cut -d'/' -f1)
+        registry=$(echo "$IMAGE" | cut -d'/' -f1 | cut -d'.' -f1)
         repository=$(echo "$IMAGE" | cut -d'/' -f2- | cut -d'@' -f1)
 
         digest=$(az acr repository show \
-          --name "${registry%.azurecr.io}" \
-          --repository "$repository" \
-          --tag "$ENVIRONMENT" \
+          --name "$registry" \
+          --image "$repository:$ENVIRONMENT" \
           --query 'digest' -o tsv)
 
         if [[ -z "${digest:-}" ]]; then
@@ -139,7 +138,7 @@ runs:
         echo "image_with_digest=$full_image" >> "$GITHUB_OUTPUT"
       env:
         IMAGE: ${{ inputs.image }}
-        ENVIRONMENT: ${{ inputs.environment }}    
+        ENVIRONMENT: ${{ inputs.environment }}
 
     - name: Get OIDC token
       shell: bash

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -117,6 +117,13 @@ runs:
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
 
+    - name: Login to Azure
+      uses: azure/login@v1
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
     - name: Get ACR image digest
       id: get-acr-digest
       shell: bash
@@ -127,6 +134,8 @@ runs:
         digest=$(az acr repository show \
           --name "$registry" \
           --image "$repository:$ENVIRONMENT" \
+          --username "$ACR_USERNAME" \
+          --password "$ACR_PASSWORD" \
           --query 'digest' -o tsv)
 
         if [[ -z "${digest:-}" ]]; then
@@ -139,6 +148,8 @@ runs:
       env:
         IMAGE: ${{ inputs.image }}
         ENVIRONMENT: ${{ inputs.environment }}
+        ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
+        ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
 
     - name: Get OIDC token
       shell: bash

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -96,43 +96,45 @@ runs:
         username: ${{ inputs.ACR_USERNAME }}
         password: ${{ inputs.ACR_PASSWORD }}
 
-    - name: Copy image to tag '${{ inputs.environment }}'
+    - name: Copy image to tag '${{ inputs.environment }}' and emit digest
+      id: copy-and-digest
       shell: bash
       run: |
-        image_without_tag_or_digest="$(echo $IMAGE | cut -d':' -f1 | cut -d'@' -f1)"
+        set -euo pipefail
+        image_without_tag_or_digest="$(echo "$IMAGE" | cut -d':' -f1 | cut -d'@' -f1)"
 
-        docker run \
-          --rm \
-          --entrypoint '/bin/sh' \
-          --env SRC_CREDS="$ACR_USERNAME:$ACR_PASSWORD" \
-          --env DEST_CREDS="$ACR_USERNAME:$ACR_PASSWORD" \
-          --env IMAGE="$IMAGE" \
-          --env IMAGE_WITHOUT_TAG_OR_DIGEST="$image_without_tag_or_digest" \
-          --env ENVIRONMENT="$ENVIRONMENT" \
-          quay.io/skopeo/stable:latest \
-          -c 'skopeo copy --preserve-digests --src-creds="$SRC_CREDS" --dest-creds="$DEST_CREDS" docker://$IMAGE docker://$IMAGE_WITHOUT_TAG_OR_DIGEST:$ENVIRONMENT'
+        # Kjør skopeo copy og skriv digest til stdout fra containeren
+        digest="$(
+          docker run \
+            --rm \
+            --entrypoint /bin/sh \
+            --env SRC_CREDS="$ACR_USERNAME:$ACR_PASSWORD" \
+            --env DEST_CREDS="$ACR_USERNAME:$ACR_PASSWORD" \
+            --env IMAGE="$IMAGE" \
+            --env IMAGE_WITHOUT_TAG_OR_DIGEST="$image_without_tag_or_digest" \
+            --env ENVIRONMENT="$ENVIRONMENT" \
+            quay.io/skopeo/stable:latest \
+            -c 'skopeo copy --preserve-digests \
+                  --src-creds="$SRC_CREDS" \
+                  --dest-creds="$DEST_CREDS" \
+                  docker://$IMAGE \
+                  docker://$IMAGE_WITHOUT_TAG_OR_DIGEST:$ENVIRONMENT \
+                  --digestfile /dev/stdout' \
+          | tr -d '\r\n'
+        )"
+
+        if [[ -z "${digest:-}" ]]; then
+          echo "Error: Could not read digest from skopeo copy"
+          exit 1
+        fi
+
+        image_with_digest="$image_without_tag_or_digest@$digest"
+        echo "image_with_digest=$image_with_digest" >> "$GITHUB_OUTPUT"
       env:
         IMAGE: ${{ inputs.image }}
         ENVIRONMENT: ${{ inputs.environment }}
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
-
-    - name: Get updated IMAGE with digest via tag for environment
-      id: get-image-with-digest
-      shell: bash
-      run: |
-        image_without_tag_or_digest="$(echo $IMAGE | cut -d':' -f1 | cut -d'@' -f1)"
-        image_with_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "$image_without_tag_or_digest:$ENVIRONMENT")
-
-        if [[ -z "$image_with_digest" ]]; then
-          echo "Error: Could not get digest for image"
-          exit 1
-        fi
-
-        echo "image_with_digest=$image_with_digest" >> "$GITHUB_OUTPUT"
-      env:
-        IMAGE: ${{ inputs.image }}
-        ENVIRONMENT: ${{ inputs.environment }}
 
     - name: Get OIDC token
       shell: bash
@@ -162,7 +164,7 @@ runs:
         CHECK_ALL_CLUSTERS: ${{ inputs.check-all-clusters }}
         ENVIRONMENT: ${{ inputs.environment }}
         # IMAGE: ${{ inputs.image }}
-        IMAGE: ${{ steps.get-image-with-digest.outputs.image_with_digest }}
+        IMAGE:  ${{ steps.copy-and-digest.outputs.image_with_digest }}
         DEPLOYVIA_URL: ${{ format('https://deployvia.{0}/deployment', (inputs.environment == 'sandbox' && 'dev-elvia.io' || 'elvia.io')) }}
 
     - name: Notify Slack on failure

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -117,6 +117,23 @@ runs:
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
 
+    - name: Get updated IMAGE with digest via tag for environment
+      id: get-image-with-digest
+      shell: bash
+      run: |
+        image_without_tag_or_digest="$(echo $IMAGE | cut -d':' -f1 | cut -d'@' -f1)"
+        image_with_digest=$(docker inspect --format='{{index .RepoDigests 0}}' "$image_without_tag_or_digest:$ENVIRONMENT")
+
+        if [[ -z "$image_with_digest" ]]; then
+          echo "Error: Could not get digest for image"
+          exit 1
+        fi
+
+        echo "image_with_digest=$image_with_digest" >> "$GITHUB_OUTPUT"
+      env:
+        IMAGE: ${{ inputs.image }}
+        ENVIRONMENT: ${{ inputs.environment }}
+
     - name: Get OIDC token
       shell: bash
       id: get-token
@@ -144,7 +161,8 @@ runs:
         CLUSTER_TYPE: ${{ inputs.cluster-type }}
         CHECK_ALL_CLUSTERS: ${{ inputs.check-all-clusters }}
         ENVIRONMENT: ${{ inputs.environment }}
-        IMAGE: ${{ inputs.image }}
+        # IMAGE: ${{ inputs.image }}
+        IMAGE: ${{ steps.get-image-with-digest.outputs.image_with_digest }}
         DEPLOYVIA_URL: ${{ format('https://deployvia.{0}/deployment', (inputs.environment == 'sandbox' && 'dev-elvia.io' || 'elvia.io')) }}
 
     - name: Notify Slack on failure

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -96,45 +96,50 @@ runs:
         username: ${{ inputs.ACR_USERNAME }}
         password: ${{ inputs.ACR_PASSWORD }}
 
-    - name: Copy image to tag '${{ inputs.environment }}' and emit digest
-      id: copy-and-digest
+    - name: Copy image to tag '${{ inputs.environment }}'
       shell: bash
       run: |
-        set -euo pipefail
-        image_without_tag_or_digest="$(echo "$IMAGE" | cut -d':' -f1 | cut -d'@' -f1)"
+        image_without_tag_or_digest="$(echo $IMAGE | cut -d':' -f1 | cut -d'@' -f1)"
 
-        # Kjør skopeo copy og skriv digest til stdout fra containeren
-        digest="$(
-          docker run \
-            --rm \
-            --entrypoint /bin/sh \
-            --env SRC_CREDS="$ACR_USERNAME:$ACR_PASSWORD" \
-            --env DEST_CREDS="$ACR_USERNAME:$ACR_PASSWORD" \
-            --env IMAGE="$IMAGE" \
-            --env IMAGE_WITHOUT_TAG_OR_DIGEST="$image_without_tag_or_digest" \
-            --env ENVIRONMENT="$ENVIRONMENT" \
-            quay.io/skopeo/stable:latest \
-            -c 'skopeo copy --preserve-digests \
-                  --src-creds="$SRC_CREDS" \
-                  --dest-creds="$DEST_CREDS" \
-                  docker://$IMAGE \
-                  docker://$IMAGE_WITHOUT_TAG_OR_DIGEST:$ENVIRONMENT \
-                  --digestfile /dev/stdout' \
-          | tr -d '\r\n'
-        )"
-
-        if [[ -z "${digest:-}" ]]; then
-          echo "Error: Could not read digest from skopeo copy"
-          exit 1
-        fi
-
-        image_with_digest="$image_without_tag_or_digest@$digest"
-        echo "image_with_digest=$image_with_digest" >> "$GITHUB_OUTPUT"
+        docker run \
+          --rm \
+          --entrypoint '/bin/sh' \
+          --env SRC_CREDS="$ACR_USERNAME:$ACR_PASSWORD" \
+          --env DEST_CREDS="$ACR_USERNAME:$ACR_PASSWORD" \
+          --env IMAGE="$IMAGE" \
+          --env IMAGE_WITHOUT_TAG_OR_DIGEST="$image_without_tag_or_digest" \
+          --env ENVIRONMENT="$ENVIRONMENT" \
+          quay.io/skopeo/stable:latest \
+          -c 'skopeo copy --preserve-digests --src-creds="$SRC_CREDS" --dest-creds="$DEST_CREDS" docker://$IMAGE docker://$IMAGE_WITHOUT_TAG_OR_DIGEST:$ENVIRONMENT'
       env:
         IMAGE: ${{ inputs.image }}
         ENVIRONMENT: ${{ inputs.environment }}
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
+
+    - name: Get ACR image digest
+      id: get-acr-digest
+      shell: bash
+      run: |
+        registry=$(echo "$IMAGE" | cut -d'/' -f1)
+        repository=$(echo "$IMAGE" | cut -d'/' -f2- | cut -d'@' -f1)
+
+        digest=$(az acr repository show \
+          --name "${registry%.azurecr.io}" \
+          --repository "$repository" \
+          --tag "$ENVIRONMENT" \
+          --query 'digest' -o tsv)
+
+        if [[ -z "${digest:-}" ]]; then
+          echo "Error: Could not retrieve digest for $repository:$ENVIRONMENT"
+          exit 1
+        fi
+
+        full_image="$registry/$repository@$digest"
+        echo "image_with_digest=$full_image" >> "$GITHUB_OUTPUT"
+      env:
+        IMAGE: ${{ inputs.image }}
+        ENVIRONMENT: ${{ inputs.environment }}    
 
     - name: Get OIDC token
       shell: bash
@@ -164,7 +169,7 @@ runs:
         CHECK_ALL_CLUSTERS: ${{ inputs.check-all-clusters }}
         ENVIRONMENT: ${{ inputs.environment }}
         # IMAGE: ${{ inputs.image }}
-        IMAGE:  ${{ steps.copy-and-digest.outputs.image_with_digest }}
+        IMAGE:  ${{ steps.get-acr-digest.outputs.image_with_digest }}
         DEPLOYVIA_URL: ${{ format('https://deployvia.{0}/deployment', (inputs.environment == 'sandbox' && 'dev-elvia.io' || 'elvia.io')) }}
 
     - name: Notify Slack on failure

--- a/deploy-argocd/action.yml
+++ b/deploy-argocd/action.yml
@@ -117,13 +117,6 @@ runs:
         ACR_USERNAME: ${{ inputs.ACR_USERNAME }}
         ACR_PASSWORD: ${{ inputs.ACR_PASSWORD }}
 
-    - name: Login to Azure
-      uses: azure/login@v1
-      with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
     - name: Get ACR image digest
       id: get-acr-digest
       shell: bash


### PR DESCRIPTION
This pull request updates the `deploy-argocd/action.yml` workflow to improve how container images are referenced and pulled from Azure Container Registry (ACR). The main enhancement is the addition of a step to resolve the image digest for the environment tag, ensuring deployments use an immutable image reference.

**Image handling improvements:**

* Added a step to retrieve the ACR image digest for the specified environment tag, and output the fully qualified image reference including the digest. This ensures deployments use immutable images, reducing the risk of deploying unintended versions.
* Updated the deployment step to use the new image reference with digest from the previous step, instead of the mutable tag-based reference.