### PR TITLE
feat(build): add docker-disable-cache input to skip cache on reruns

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -39,6 +39,12 @@ inputs:
   docker-build-args:
     description: 'Comma-separated list of build arguments to pass to Docker when building, e.g. `ARG1=value1,ARG2=value2`.'
     required: false
+  docker-disable-cache:
+    description: |
+      Disable Docker layer caching. When `true`, the build will not use cached layers from the registry.
+      Defaults to `true` on re-runs and manual workflow dispatches, ensuring fresh builds pick up security patches.
+    required: false
+    default: ${{ github.run_attempt > 1 || github.event_name == 'workflow_dispatch' }}
   severity:
     description: |
       Severity levels to scan for.
@@ -198,6 +204,7 @@ runs:
         3LV_CACHE_TAG: ${{ inputs.docker-cache-tag }}
         3LV_BUILD_ARGS: ${{ inputs.docker-build-args }}
         3LV_SCAN_SEVERITY: ${{ inputs.severity }}
+        3LV_DISABLE_CACHE: ${{ inputs.docker-disable-cache }}
         3LV_AZURE_TENANT_ID: ${{ inputs.AZURE_TENANT_ID }}
         3LV_AZURE_CLIENT_ID: ${{ inputs.AZURE_CLIENT_ID }}
         3LV_AZURE_FEDERATED_TOKEN: ${{ steps.get-federated-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Adds new `docker-disable-cache` input to the build action
- Defaults to `true` on re-runs (`github.run_attempt > 1`) and manual workflow dispatches
- Passes the value to 3lv CLI via `3LV_DISABLE_CACHE` environment variable

## Why
When Trivy detects a CVE in cached Docker layers (e.g., from `apk upgrade`), developers currently cannot get a fresh build without code changes. This makes it so re-running a workflow automatically disables cache, allowing security patches to be applied.

## Dependencies
Requires 3lvia/cli#239 to be merged first (adds `--disable-cache` flag to CLI).

## Usage
The input defaults to smart behavior - most builds will still use cache for speed, but re-runs and manual dispatches will get fresh builds:

```yaml
- uses: 3lvia/core-github-actions-templates/build@trunk
  with:
    name: my-app
    # docker-disable-cache defaults to true on re-runs
```

To explicitly disable cache:
```yaml
- uses: 3lvia/core-github-actions-templates/build@trunk
  with:
    name: my-app
    docker-disable-cache: 'true'
```