### PR TITLE
GKE deployment fails on elvia-runner without setup-gcloud

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -133,10 +133,9 @@ runs:
         workload_identity_provider: ${{ inputs.GC_WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ inputs.GC_SERVICE_ACCOUNT }}
 
-    - name: Setup Google Cloud CLI with GKE auth plugin if not on Elvia runner
+    - name: Setup Google Cloud CLI with GKE auth plugin
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       if: ${{ inputs.runtime-cloud-provider == 'GKE' }}
-      # if: ${{ inputs.runtime-cloud-provider == 'GKE' && !startsWith(runner.name, 'elvia-runner-') }}
       with:
         install_components: 'gke-gcloud-auth-plugin'
 

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -135,7 +135,8 @@ runs:
 
     - name: Setup Google Cloud CLI with GKE auth plugin if not on Elvia runner
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-      if: ${{ inputs.runtime-cloud-provider == 'GKE' && !startsWith(runner.name, 'elvia-runner-') }}
+      if: ${{ inputs.runtime-cloud-provider == 'GKE' }}
+      # if: ${{ inputs.runtime-cloud-provider == 'GKE' && !startsWith(runner.name, 'elvia-runner-') }}
       with:
         install_components: 'gke-gcloud-auth-plugin'
 
@@ -155,8 +156,6 @@ runs:
       run: |
         gcloud auth list
         gcloud config list
-        kubectl config get-contexts
-        kubectl get nodes
 
     - name: Install 3lv CLI
       uses: 3lvia/cli/setup@trunk

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -149,13 +149,6 @@ runs:
           monitoring/kv/data/shared grafana_api_url        | GRAFANA_URL ;
           monitoring/kv/data/shared grafana_editor_api_key | GRAFANA_API_KEY
 
-    - name: Bug Hunt
-      shell: bash
-      if: ${{ inputs.runtime-cloud-provider == 'GKE' }}
-      run: |
-        gcloud auth list
-        gcloud config list
-
     - name: Install 3lv CLI
       uses: 3lvia/cli/setup@trunk
       with:

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -149,6 +149,15 @@ runs:
           monitoring/kv/data/shared grafana_api_url        | GRAFANA_URL ;
           monitoring/kv/data/shared grafana_editor_api_key | GRAFANA_API_KEY
 
+    - name: Bug Hunt
+      shell: bash
+      if: ${{ inputs.runtime-cloud-provider == 'GKE' }}
+      run: |
+        gcloud auth list
+        gcloud config list
+        kubectl config get-contexts
+        kubectl get nodes
+
     - name: Install 3lv CLI
       uses: 3lvia/cli/setup@trunk
       with:


### PR DESCRIPTION
Noe må ha skjedd i elvia-runner, for nå fungerer ikke lenger autentiseringen uten at vi kjører setup-gcloud i workflow. Det skal egentlig være installert på forhånd.

Denne fiksen gjør at det installeres, så får vi vurdere å sjekke hva som har gått galt med installasjonen. Endringen skjedde 9. juni.