### PR TITLE
docs: state that Build's registry input does not steer Deploy

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -90,6 +90,14 @@ inputs:
 
       If set to a GHCR registry, the action will push to the GitHub Container Registry of the repository.
       Using GHCR requires the `packages: write` permission to push to the registry.
+
+      **This input does not affect where `Deploy` looks for the image.** `Deploy` only sets
+      `image.tag`; the repository comes from the Helm chart, which defaults to
+      `containerregistryelvia.azurecr.io/$namespace-$name`. So if you push somewhere other than
+      Elvia's ACR and then deploy with the `Deploy` action, you must also set `image.repository`
+      (or the per-environment `image.<env>.repository`) in your Helm values file — otherwise the
+      pod ends up in `ImagePullBackOff` and the deploy fails on a rollout timeout several minutes
+      later, with no mention of the image in the error.
     required: false
   push:
     description: 'If `true`, the action will push the Docker image to the registry.'

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -2,9 +2,16 @@ name: 'Deploy'
 description: |
   Deploys an application to Kubernetes using the Elvia Helm chart.
   This action is a wrapper around the [3lv CLI](https://github.com/3lvia/cli) deploy command (`3lv deploy`).
+
   To use the `Build` and `Deploy` actions with Elvias container registry and runtime services,
   you must first add your GitHub repository to [github-repositories-terraform](https://github.com/3lvia/github-repositories-terraform).
   If you are running on ISS, you should add the repository to [iss-terraform](https://github.com/3lvia/iss-terraform) instead.
+
+  This action sets only the image *tag*. The image repository comes from the Helm chart and
+  defaults to `containerregistryelvia.azurecr.io/$namespace-$name`, so there is no `registry`
+  input here. If `Build` pushed somewhere else (e.g. GHCR), override `image.repository` in your
+  Helm values file to match — otherwise this action deploys a reference to an image that does
+  not exist, and fails on a rollout timeout rather than a missing-image error.
 inputs:
   name:
     description: 'Name of application. Do not include namespace.'


### PR DESCRIPTION
`Build` has a `registry` input and documents GHCR as a supported target. `Deploy` has no such input — it only sets `image.tag`, and the repository comes from the Helm chart, defaulting to `containerregistryelvia.azurecr.io/$namespace-$name`.

Choose GHCR in `Build`, then deploy with `Deploy`, and the deployment points at an image that was never pushed there. Nothing fails early: `Build` is green, `helm upgrade --install` is green, and the job dies minutes later on `exceeded its progress deadline` — a message that says nothing about the image. The actual cause (`ImagePullBackOff`, `not found`) is only visible in `kubectl get events`, which most developers won't reach for.

We hit this for real today in `ifs-extensions-safetycardholder-publisher` (ISS→Atlas migration): build pushed to GHCR, deploy looked in ACR, and it cost the team about an hour before it was escalated.

Worth being precise about the gap: the combination **is** expressible — the chart supports overriding `image.repository`, including [per environment](https://github.com/3lvia/kubernetes-charts/blob/trunk/charts/elvia-deployment/templates/_helpers.tpl). It just isn't discoverable from either action, and nothing tells you when you've got it wrong. So this is a documentation fix, not a missing capability.

Changes the input description in `build/action.yml` and the action description in `deploy/action.yml` to state the coupling in both directions.

`README.md` is generated from `action.yml` on push to trunk, so it isn't edited here — it will pick this up after merge.

## Worth considering separately

A doc fix removes the trap only for people who read the docs. Two options that would actually catch it, both bigger than this PR:

- Have `Deploy` verify the image exists before rolling out. `3lv` already has a `getImageDigest` for this, currently commented out and `//nolint:unused` in `pkg/deploy/deploy.go` — presumably disabled for a reason worth knowing before re-enabling. This would turn a ten-minute opaque timeout into an immediate, clear error, and would also catch unrelated missing-image cases.
- Add a `registry` input to `Deploy` threaded through to `3lv deploy`, so the two halves are symmetric. Requires a change in `3lvia/cli` as well.