### PR TITLE
Upload raw .trx test results as workflow artifacts

### DIFF
--- a/integrationtest/action.yml
+++ b/integrationtest/action.yml
@@ -31,6 +31,16 @@ inputs:
     required: false
     default: ''
 
+  test-results-artifact-name:
+    description:
+      'Name of the workflow artifact that the raw .trx test result files are uploaded to. Must be unique within the
+      workflow run.'
+    required: false
+    default: 'integration-test-results-${{ github.job }}'
+  test-results-retention-days:
+    description: 'How many days to keep the uploaded test result artifact.'
+    required: false
+    default: '14'
 runs:
   using: 'composite'
   steps:
@@ -68,6 +78,20 @@ runs:
       env:
         TEST_PROJECTS: ${{ inputs.test-projects }}
       working-directory: ${{ inputs.working-directory }}
+
+    # The published check summary only carries outcomes; the raw .trx also has per-test timings,
+    # start/end times and full failure details — and passed/skipped tests leave no other trace.
+    # Without this upload the files die with the runner.
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      with:
+        name: ${{ inputs.test-results-artifact-name }}
+        path: |
+          **/TestResults/*.trx
+          .github/**/TestResults/*.trx
+        retention-days: ${{ inputs.test-results-retention-days }}
+        if-no-files-found: ignore
 
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0

--- a/playwright/action.yml
+++ b/playwright/action.yml
@@ -19,6 +19,16 @@ inputs:
     required: false
     default: 'Debug'
 
+  test-results-artifact-name:
+    description:
+      'Name of the workflow artifact that the raw .trx test result files are uploaded to. Must be unique within the
+      workflow run.'
+    required: false
+    default: 'smoketest-results-${{ github.job }}'
+  test-results-retention-days:
+    description: 'How many days to keep the uploaded test result artifact.'
+    required: false
+    default: '14'
 runs:
   using: 'composite'
   steps:
@@ -50,6 +60,20 @@ runs:
       env:
         CONFIGURATION: ${{ inputs.configuration }}
         TEST_PROJECT: ${{ inputs.test-project }}
+
+    # The published check summary only carries outcomes; the raw .trx also has per-test timings,
+    # start/end times and full failure details — and passed/skipped tests leave no other trace.
+    # Without this upload the files die with the runner.
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      with:
+        name: ${{ inputs.test-results-artifact-name }}
+        path: |
+          **/TestResults/*.trx
+          .github/**/TestResults/*.trx
+        retention-days: ${{ inputs.test-results-retention-days }}
+        if-no-files-found: ignore
 
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0

--- a/unittest/action.yml
+++ b/unittest/action.yml
@@ -30,6 +30,16 @@ inputs:
     required: false
     default: ''
 
+  test-results-artifact-name:
+    description:
+      'Name of the workflow artifact that the raw .trx test result files are uploaded to. Must be unique within the
+      workflow run.'
+    required: false
+    default: 'unit-test-results-${{ github.job }}'
+  test-results-retention-days:
+    description: 'How many days to keep the uploaded test result artifact.'
+    required: false
+    default: '14'
 runs:
   using: 'composite'
   steps:
@@ -70,6 +80,20 @@ runs:
         TEST_COVERAGE: ${{ inputs.test-coverage }}
         COVERLET_RUNSETTINGS_FILE: ${{ inputs.coverlet-runsettings-file }}
       working-directory: ${{ inputs.working-directory }}
+
+    # The published check summary only carries outcomes; the raw .trx also has per-test timings,
+    # start/end times and full failure details — and passed/skipped tests leave no other trace.
+    # Without this upload the files die with the runner.
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      with:
+        name: ${{ inputs.test-results-artifact-name }}
+        path: |
+          **/TestResults/*.trx
+          .github/**/TestResults/*.trx
+        retention-days: ${{ inputs.test-results-retention-days }}
+        if-no-files-found: ignore
 
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0


### PR DESCRIPTION
## Hva

`unittest`, `integrationtest` og `playwright` kjører `dotnet test -l:trx`, men rå-filene dør med runneren — bare EnricoMi-summaryen overlever. Ett nytt steg per template laster dem opp som workflow-artifact.

## Hvorfor — det vi støtte på i elvid

Sjekken viser bare utfall; trx-en har per-test-timing og fulle feildetaljer — beståtte og skippede tester etterlater ellers ingen spor. Det kostet oss konkret:

- En ekstern BankID-testbruker døde stille → fire smoke-tester skippet **i ukevis**. Alt GA viste var `Skipped: 4`, og ingen reagerte — VerifyName-flyten sto udekket uten at noen visste det.
- Da elvid la på nøyaktig dette steget (elvid#909), viste trx-en **på minutter** at hvert skip kostet ~37 s (2,5 min per kjøring, per miljø), pekte på den døde testbrukeren, og verifiserte etterpå både gjenopprettet dekning og målt speedup 6m20 → 4m09.

Verdien er altså demonstrert, ikke antatt: uten fila var problemet usynlig i ukevis; med fila tok diagnosen minutter. Vi hadde dette i Azure DevOps (`PublishTestResults@2` med `condition: always()`, per-test-historikk i Tests-fanen) — evnen forsvant stille i GA-migreringen.

## Utforming og kost

- `if: always()` + `if-no-files-found: ignore` — kan aldri endre utfallet av en kjøring
- Artifact-navn og retensjon (default 14 d) er inputs; navn-default suffikses med `${{ github.job }}` så to templates i samme jobb ikke kolliderer (`upload-artifact` v4+ feiler på duplikatnavn)
- Målt 2026-08-18: 154 workflows i 110 repoer, ~1 200 invokasjoner/uke. Artifact-størrelser målt i elvid-canaryen (elvid#911): unit 203 KB, integration 65 KB, smoke 8 KB (lagres komprimert) → ~300 MB stående ved 14 d retensjon ≈ **0,6 % av inkludert Enterprise-kvote, $0** (org-ens totale Actions-lagring i dag: ~0,01 %, $0.00)

Konsumentene refererer `@trunk`, så merge er umiddelbar utrulling til alle repoer; eneste synlige endring er Artifacts-seksjonen på run-siden. README-tabellene genereres automatisk på trunk.
