### PR TITLE
Preinstall Playwright browsers in the ARC runner image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
+  "extends": ["config:recommended",
+    "customManagers:dockerfileVersions", "helpers:pinGitHubActionDigestsToSemver"],
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {

--- a/arc/Dockerfile
+++ b/arc/Dockerfile
@@ -185,6 +185,28 @@ RUN apt-get install -y --no-install-recommends \
         libxcomposite1 \
         libatomic1
 
+# Preinstall Playwright browsers and their full OS dependency set, so the playwright
+# template's install step becomes a fast no-op instead of downloading three browsers on
+# every ephemeral runner pod (measured in elvid 2026-08-18: ~1.2 min x 3 deploy jobs =
+# ~3.7 min per pipeline, plus an actions/cache workaround this makes redundant).
+#
+# The version must track Microsoft.Playwright in consumer repos (elvid: 1.48.0; the
+# browser revisions are identical across the Node and .NET bindings of the same version).
+# On mismatch Playwright falls back to downloading at runtime into the same path — slower,
+# never broken; that is also why the path is left world-writable.
+ARG PLAYWRIGHT_VERSION=1.48.0
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium firefox webkit && \
+    chmod -R 777 /ms-playwright
+
+# Playwright 1.48 browser builds link against older ICU/vpx than Ubuntu 24.04 (noble)
+# ships. Same workaround consumer workflows carry today (elvid.yaml); belongs here so
+# they can drop it.
+RUN ln -sf /usr/lib/x86_64-linux-gnu/libicudata.so.74 /usr/lib/x86_64-linux-gnu/libicudata.so.70 && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libicui18n.so.74 /usr/lib/x86_64-linux-gnu/libicui18n.so.70 && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libicuuc.so.74 /usr/lib/x86_64-linux-gnu/libicuuc.so.70 && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libvpx.so.9 /usr/lib/x86_64-linux-gnu/libvpx.so.7
+
 # Install Postgres
 RUN apt-get install -y --no-install-recommends postgresql-client
 

--- a/arc/Dockerfile
+++ b/arc/Dockerfile
@@ -185,15 +185,11 @@ RUN apt-get install -y --no-install-recommends \
         libxcomposite1 \
         libatomic1
 
-# Preinstall Playwright browsers and their full OS dependency set, so the playwright
-# template's install step becomes a fast no-op instead of downloading three browsers on
-# every ephemeral runner pod (measured in elvid 2026-08-18: ~1.2 min x 3 deploy jobs =
-# ~3.7 min per pipeline, plus an actions/cache workaround this makes redundant).
-#
-# The version must track Microsoft.Playwright in consumer repos (elvid: 1.62.0, elvid#913;
-# the browser revisions are identical across the Node and .NET bindings of the same
-# version). On mismatch Playwright falls back to downloading at runtime into the same
-# path — slower, never broken; that is also why the path is left world-writable.
+# Preinstall Playwright browsers and OS deps so the playwright template's install step
+# becomes a fast no-op (measured: ~1.2 min x 3 deploy jobs per pipeline). Tracks
+# Microsoft.Playwright in consumer repos; on mismatch Playwright downloads at runtime
+# into this world-writable path — slower, never broken.
+# renovate: datasource=npm depName=playwright
 ARG PLAYWRIGHT_VERSION=1.62.0
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium firefox webkit && \

--- a/arc/Dockerfile
+++ b/arc/Dockerfile
@@ -199,9 +199,11 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium firefox webkit && \
     chmod -R 777 /ms-playwright
 
-# Playwright 1.48 browser builds link against older ICU/vpx than Ubuntu 24.04 (noble)
-# ships. Same workaround consumer workflows carry today (elvid.yaml); belongs here so
-# they can drop it.
+# Playwright 1.48's browser builds (notably WebKit) link against older ICU/vpx than
+# Ubuntu 24.04 (noble) ships, and install-deps does not fix that — verified empirically:
+# elvid added exactly these symlinks 2026-02-05 while already on 1.48 (elvid@9a728e9d).
+# The .so.70/.so.7 names do not exist on noble, so the links shadow nothing and are inert
+# if a future PLAYWRIGHT_VERSION bump ships proper noble builds — revisit on bump.
 RUN ln -sf /usr/lib/x86_64-linux-gnu/libicudata.so.74 /usr/lib/x86_64-linux-gnu/libicudata.so.70 && \
     ln -sf /usr/lib/x86_64-linux-gnu/libicui18n.so.74 /usr/lib/x86_64-linux-gnu/libicui18n.so.70 && \
     ln -sf /usr/lib/x86_64-linux-gnu/libicuuc.so.74 /usr/lib/x86_64-linux-gnu/libicuuc.so.70 && \

--- a/arc/Dockerfile
+++ b/arc/Dockerfile
@@ -190,24 +190,15 @@ RUN apt-get install -y --no-install-recommends \
 # every ephemeral runner pod (measured in elvid 2026-08-18: ~1.2 min x 3 deploy jobs =
 # ~3.7 min per pipeline, plus an actions/cache workaround this makes redundant).
 #
-# The version must track Microsoft.Playwright in consumer repos (elvid: 1.48.0; the
-# browser revisions are identical across the Node and .NET bindings of the same version).
-# On mismatch Playwright falls back to downloading at runtime into the same path — slower,
-# never broken; that is also why the path is left world-writable.
-ARG PLAYWRIGHT_VERSION=1.48.0
+# The version must track Microsoft.Playwright in consumer repos (elvid: 1.62.0, elvid#913;
+# the browser revisions are identical across the Node and .NET bindings of the same
+# version). On mismatch Playwright falls back to downloading at runtime into the same
+# path — slower, never broken; that is also why the path is left world-writable.
+ARG PLAYWRIGHT_VERSION=1.62.0
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps chromium firefox webkit && \
     chmod -R 777 /ms-playwright
 
-# Playwright 1.48's browser builds (notably WebKit) link against older ICU/vpx than
-# Ubuntu 24.04 (noble) ships, and install-deps does not fix that — verified empirically:
-# elvid added exactly these symlinks 2026-02-05 while already on 1.48 (elvid@9a728e9d).
-# The .so.70/.so.7 names do not exist on noble, so the links shadow nothing and are inert
-# if a future PLAYWRIGHT_VERSION bump ships proper noble builds — revisit on bump.
-RUN ln -sf /usr/lib/x86_64-linux-gnu/libicudata.so.74 /usr/lib/x86_64-linux-gnu/libicudata.so.70 && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libicui18n.so.74 /usr/lib/x86_64-linux-gnu/libicui18n.so.70 && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libicuuc.so.74 /usr/lib/x86_64-linux-gnu/libicuuc.so.70 && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libvpx.so.9 /usr/lib/x86_64-linux-gnu/libvpx.so.7
 
 # Install Postgres
 RUN apt-get install -y --no-install-recommends postgresql-client


### PR DESCRIPTION
## Hva

Playwright-nettleserne (v1.62.0) og OS-avhengighetene deres bakes inn i `ghcr.io/3lvia/actions-runner`, med `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`. Versjonen Renovate-styres via `customManagers:dockerfileVersions` + annotasjon, så den ikke drifter slik konsument-pinnen fra 2023 gjorde.

## Hvorfor

Hver deploy-jobb med GUI-smoke laster i dag ned tre nettlesere på en fersk runner-pod: målt i elvid til **~1,2 min × 3 jobber per pipeline**. Med nettleserne i imaget blir playwright-templatens install-steg en rask no-op.

Ingen symlink-workarounds: verifisert i elvid#913 at Playwright 1.62 kjører rent på noble — 40/40 tester inkl. reell WebKit-kjøring, med høylytt-skip-guard som gjør beviset positivt.

## Risiko

- Versjonsavvik hos konsument = runtime-nedlasting til samme (verdensskrivbare) sti — tregt, aldri ødelagt
- +~1,3 GB image, amortisert av daglig prebuild + node-cache

Bør merges etter/sammen med elvid#913. Berører delt runner-infrastruktur — Rune bør ta et blikk.
