### PR TITLE
Hotfix: trx-artifactnavn unikt per invokasjon + continue-on-error

### DIFF
--- a/integrationtest/action.yml
+++ b/integrationtest/action.yml
@@ -36,7 +36,7 @@ inputs:
       'Name of the workflow artifact that the raw .trx test result files are uploaded to. Must be unique within the
       workflow run.'
     required: false
-    default: 'integration-test-results-${{ github.job }}'
+    default: 'integration-test-results-${{ github.job }}-${{ github.action }}'
   test-results-retention-days:
     description: 'How many days to keep the uploaded test result artifact.'
     required: false
@@ -84,6 +84,7 @@ runs:
     # Without this upload the files die with the runner.
     - name: Upload test results
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.test-results-artifact-name }}

--- a/playwright/action.yml
+++ b/playwright/action.yml
@@ -24,7 +24,7 @@ inputs:
       'Name of the workflow artifact that the raw .trx test result files are uploaded to. Must be unique within the
       workflow run.'
     required: false
-    default: 'smoketest-results-${{ github.job }}'
+    default: 'smoketest-results-${{ github.job }}-${{ github.action }}'
   test-results-retention-days:
     description: 'How many days to keep the uploaded test result artifact.'
     required: false
@@ -66,6 +66,7 @@ runs:
     # Without this upload the files die with the runner.
     - name: Upload test results
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.test-results-artifact-name }}

--- a/unittest/action.yml
+++ b/unittest/action.yml
@@ -35,7 +35,7 @@ inputs:
       'Name of the workflow artifact that the raw .trx test result files are uploaded to. Must be unique within the
       workflow run.'
     required: false
-    default: 'unit-test-results-${{ github.job }}'
+    default: 'unit-test-results-${{ github.job }}-${{ github.action }}'
   test-results-retention-days:
     description: 'How many days to keep the uploaded test result artifact.'
     required: false
@@ -86,6 +86,7 @@ runs:
     # Without this upload the files die with the runner.
     - name: Upload test results
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.test-results-artifact-name }}


### PR DESCRIPTION
409-kollisjon når samme test-template kalles flere ganger i én jobb (traff mmm-tidsfrist-api og kunde-metervalue-api i dag). Default-navnet får `${{ github.action }}`-suffiks (unik composite-invokasjons-ID i jobben), og upload-steget får `continue-on-error: true` — diagnostikk skal aldri kunne velte et bygg.