### PR TITLE
ci: verify action docs on PR instead of bot-pushing to trunk

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -1,8 +1,11 @@
-name: Generate action documentation
+name: Verify action documentation
+
+# README.md is generated from the action.yml files. This check regenerates it on
+# every pull request and fails if the committed README is out of date, so the
+# contributor updates it before merge. Nothing is pushed to trunk by a bot.
 
 on:
-  push:
-    branches: [trunk]
+  pull_request:
     paths:
       - '.github/workflows/generate-docs.yaml'
       - '**/action.yml'
@@ -10,18 +13,20 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event_name }}'
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:
-  generate-docs:
-    name: Generate action documentation
+  verify-docs:
+    name: Verify action documentation
     runs-on: elvia-runner
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Generate docs
         uses: 3lvia/gh-actions-docs@2db29362f0d6d92052f6fa49b71743af5f0c11f8 # v1
@@ -30,20 +35,17 @@ jobs:
           ignore-headers: '# core-github-actions-templates,## Table of Contents'
           run-prettier: 'true'
 
-      - name: Commit changes
+      - name: Fail if README.md is out of date
         shell: bash
         run: |
-          if [[ -z "$(git status --porcelain)" ]]; then
-            echo 'No changes to commit.'
+          if git diff --quiet -- README.md; then
+            echo 'README.md is up to date.'
             exit 0
           fi
 
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-          git add README.md
-          git commit -m 'Update action documentation'
-          git push
-        env:
-          GH_TOKEN: ${{ github.token }}
-
+          echo '::error file=README.md::README.md is out of date with the action.yml files.'
+          echo
+          echo 'Regenerate it by running this workflow locally, or apply the diff below:'
+          echo
+          git --no-pager diff -- README.md
+          exit 1


### PR DESCRIPTION
## Hvorfor

\`trunk\` krever nå pull request + signerte commits (ruleset oppdatert i dag). Docs-jobben pusher README-oppdateringer rett til trunk som \`github-actions[bot]\` og vil feile med GH013 ved neste merge.

## Hva

Snur \`generate-docs.yaml\` fra bot-push til PR-sjekk:

- kjører på \`pull_request\` (samme path-filter) i stedet for \`push: trunk\`
- genererer README med \`3lvia/gh-actions-docs\` som før, og **feiler** hvis den committede README avviker — med diffen i loggen
- \`permissions: contents: read\` (var \`write\`), \`persist-credentials: false\`

Bidragsyteren committer oppdatert README selv før merge. Ingen bot trenger skrivetilgang til trunk, ingen bypass i rulesetet.

## Verifisert

- Repoets eget \`verify_action_pinning.py\` godkjenner alle 16 workflows.
- Denne PR-en endrer selve workflow-fila, så sjekken kjører på PR-en og skal være grønn (README er i synk).